### PR TITLE
ntpd.conf: Remove "disable monitor" to get rid of log warnings

### DIFF
--- a/src/etc/inc/plugins.inc.d/ntpd.inc
+++ b/src/etc/inc/plugins.inc.d/ntpd.inc
@@ -340,9 +340,6 @@ function ntpd_configure_do($verbose = false)
 
     $ntpcfg .= "\n\n";
 
-    /* prevent NTP reflection attack, see https://ics-cert.us-cert.gov/advisories/ICSA-14-051-04 */
-    $ntpcfg .= "disable monitor\n";
-
     if (
         !empty($config['ntpd']['clockstats']) ||
         !empty($config['ntpd']['loopstats']) ||


### PR DESCRIPTION
There is a log message "2023-02-12T14:33:48	Warning	ntpd	restrict: 'monitor' cannot be disabled while 'limited' is enabled" ever so often when rate limiting is enabled. Disabling rate limiting is not advisable and even then, there will be another warning because certain combinations of rate limiting and kiss-of-death are chosen. ntpd options should probably be overhauled anyway.

However, according to the referenced https://www.cisa.gov/uscert/ics/advisories/ICSA-14-051-04, this issue has been fixed long ago. The current version 4.2.8 of ntpd is not longer vulnerable to this, such that "disable monitor" is no longer neccessary.