### PR TITLE
Update temperature.sh for smaller CPU footprint

### DIFF
--- a/src/opnsense/scripts/system/temperature.sh
+++ b/src/opnsense/scripts/system/temperature.sh
@@ -31,7 +31,7 @@
 # read until we have asked the kernel.  Caching this and unifying
 # with RRD collection is a worthwile goal.  No hackery in the
 # meantime to avoid adding something we cannot get rid of later.
-SYSCTLS=$(sysctl -aN | grep temperature)
+SYSCTLS=$(sysctl -N dev.cpu hw.acpi.thermal | fgrep temperature)
 if [ -n "${SYSCTLS}" ]; then
 	sysctl -e ${SYSCTLS} | sort
 fi


### PR DESCRIPTION
This patch eliminates many lines of output from sysctl and searches it much faster, because there is no regex matching.

This results in a smaller CPU footprint, thus reducing the impact of temperature monitoring itself on the reported temps, without changing the outcome.

See also: https://forum.opnsense.org/index.php?topic=36234.0